### PR TITLE
Do not remove the old web-platform-tests repo

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -27,11 +27,6 @@
                 state=present
     notify: Restart ssh
 
-  - name: remove old repo
-    file:
-      path: /root/web-platform-tests
-      state: absent
-
   - name: checkout the web-platform-tests
     git:
       repo: 'https://github.com/w3c/web-platform-tests.git'


### PR DESCRIPTION
We don't need to do this so I'm removing this step.