### PR TITLE
WIP Docker experiment (do not merge)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7-slim
+
+RUN mkdir /web-platform-tests
+WORKDIR /web-platform-tests
+
+ADD . /web-platform-tests/
+RUN echo '{"ports":{"http":[80,"auto"],"https":[443]},"bind_address":false}' > /web-platform-tests/config.json
+
+EXPOSE 80
+EXPOSE 443
+
+CMD [ "python", "wpt", "serve" ]
+

--- a/files/docker.wpt.service
+++ b/files/docker.wpt.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=WPT Container
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker swarm leave --force
+ExecStartPre=-/usr/bin/docker swarm init --advertise-addr 172.30.1.5
+ExecStartPre=/usr/bin/docker pull bmac/wpt
+ExecStartPre=/usr/bin/docker service create -p 80:80 --host=xn--lve-6lad.not-web-platform.test:127.0.0.1 --host=xn--lve-6lad.web-platform.test:127.0.0.1 --host=xn--n8j6ds53lwwkrqhv28a.not-web-platform.test:127.0.0.1 --host=www1.web-platform.test:127.0.0.1 --host=www2.web-platform.test:127.0.0.1 --host=not-web-platform.test:127.0.0.1 --host=web-platform.test:127.0.0.1 --host=www2.not-web-platform.test:127.0.0.1 --host=www1.not-web-platform.test:127.0.0.1 --host=www.not-web-platform.test:127.0.0.1 --host=www.web-platform.test:127.0.0.1 --host=xn--n8j6ds53lwwkrqhv28a.web-platform.test:127.0.0.1 --name wpt-service bmac/wpt
+ExecStart=/usr/bin/docker service logs wpt-service --follow
+
+[Install]
+WantedBy=multi-user.target

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,6 +20,19 @@
         - python-pip
         - unattended-upgrades
 
+  - name:    Add Docker GPG key
+    apt_key: url=https://download.docker.com/linux/ubuntu/gpg
+
+  - name:    Add Docker APT repository
+    apt_repository:
+      repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+
+  - name:    Install Docker
+    apt:
+      name: docker-ce
+      state: present
+      update_cache: yes
+
   - name: Disallow password authentication
     lineinfile: dest=/etc/ssh/sshd_config
                 regexp="^PasswordAuthentication"
@@ -27,48 +40,15 @@
                 state=present
     notify: Restart ssh
 
-  - name: checkout the web-platform-tests
-    git:
-      repo: 'https://github.com/web-platform-tests/wpt.git'
-      dest: ~/web-platform-tests
-      force: yes
-
-  - name: make python virtualenv
-    pip:
-      name: virtualenv
-      virtualenv: ~/web-platform-tests/_venv
-
-  - name: ensure wpt service is configured
+  - name: ensure wpt docker service is configured
     template:
-      src: files/wpt.service
+      src: files/docker.wpt.service
       dest: /etc/systemd/system/
-
-  - name: ensure conditional restart script is in the correct location
-    template:
-      src: files/wpt-pull-and-restart.sh
-      dest: /root/
-      owner: root
-      mode: '0700'
-
-  - name: ensure config.json is in the correct location
-    template:
-      src: files/config.json
-      dest: /root/web-platform-tests/
-
-  - name: Collect list of host aliases
-    shell: /root/web-platform-tests/wpt make-hosts-file
-    register: hosts_file_contents
-
-  - name: Update the hosts file
-    lineinfile:
-      line: '{{item}}'
-      dest: /etc/hosts
-    with_items: '{{hosts_file_contents.stdout_lines}}'
 
   - name: Enable the wpt service in systemd
     systemd:
       enabled: True
-      name: wpt
+      name: docker.wpt
       state: started
 
   - include: certbot.yml
@@ -76,20 +56,10 @@
 
   - name: Add cron job to sync wpt
     cron:
-      name: Synchronize WPT
-      job: "/root/wpt-pull-and-restart.sh"
+      name: Redeploy a new docker service every minute
+      job: "docker pull bmac/wpt && docker service update --image bmac/wpt:latest wpt-service"
       minute: "*"
-
   
-  # force_restart is false by default this can be set via the command line using --extra-vars
-  # $ ansible-playbook playbook.yml --extra-vars "force_restart=true"
-  - name: reboot the machine
-    command: /sbin/shutdown -r +1
-    async: 0
-    poll: 0
-    ignore_errors: true
-    when: force_restart
-
   handlers:
     - name: Restart ssh
       service: name=ssh state=restarted


### PR DESCRIPTION
Mike this is my experimentation with docker swarm to get 0 downtime upgrades of the docker instance running web-platform test. It is not production ready but I will leave comments for areas to improve where I can.

This pr is not intended to be merged and instead used as reference for future docker work.

My docker-fu is weak but from what I understand `docker swarm` is a competitor to kubernetes. You may find kubernetes is a better choice here since it is more popular the only reason I went with docker swarm was because it is installed by default with the `docker-ce` package and I had some very minor exposure to it via a pluralsight docker course I once watched.

