### PR TITLE
Request certificate for all supported subdomains

### DIFF
--- a/certbot.yml
+++ b/certbot.yml
@@ -25,18 +25,68 @@
       {{ (env == 'production') | ternary('', '--test-cert') }}
       --email {{letsencrypt_email}}
       -w /root/web-platform-tests
-      -d {{fqdn}}
+      -d web-platform-tests.live
       -d not-web-platform-tests.live
-      -d xn--lve-6lad.web-platform-tests.live
-      -d xn--lve-6lad.not-web-platform-tests.live
-      -d xn--n8j6ds53lwwkrqhv28a.web-platform-tests.live
-      -d xn--n8j6ds53lwwkrqhv28a.not-web-platform-tests.live
-      -d www1.web-platform-tests.live
-      -d www1.not-web-platform-tests.live
-      -d www2.web-platform-tests.live
-      -d www2.not-web-platform-tests.live
-      -d www.web-platform-tests.live
       -d www.not-web-platform-tests.live
+      -d www.web-platform-tests.live
+      -d www.www.not-web-platform-tests.live
+      -d www.www.web-platform-tests.live
+      -d www.www1.not-web-platform-tests.live
+      -d www.www1.web-platform-tests.live
+      -d www.www2.not-web-platform-tests.live
+      -d www.www2.web-platform-tests.live
+      -d www.xn--lve-6lad.not-web-platform-tests.live
+      -d www.xn--lve-6lad.web-platform-tests.live
+      -d www.xn--n8j6ds53lwwkrqhv28a.not-web-platform-tests.live
+      -d www.xn--n8j6ds53lwwkrqhv28a.web-platform-tests.live
+      -d www1.not-web-platform-tests.live
+      -d www1.web-platform-tests.live
+      -d www1.www.not-web-platform-tests.live
+      -d www1.www.web-platform-tests.live
+      -d www1.www1.not-web-platform-tests.live
+      -d www1.www1.web-platform-tests.live
+      -d www1.www2.not-web-platform-tests.live
+      -d www1.www2.web-platform-tests.live
+      -d www1.xn--lve-6lad.not-web-platform-tests.live
+      -d www1.xn--lve-6lad.web-platform-tests.live
+      -d www1.xn--n8j6ds53lwwkrqhv28a.not-web-platform-tests.live
+      -d www1.xn--n8j6ds53lwwkrqhv28a.web-platform-tests.live
+      -d www2.not-web-platform-tests.live
+      -d www2.web-platform-tests.live
+      -d www2.www.not-web-platform-tests.live
+      -d www2.www.web-platform-tests.live
+      -d www2.www1.not-web-platform-tests.live
+      -d www2.www1.web-platform-tests.live
+      -d www2.www2.not-web-platform-tests.live
+      -d www2.www2.web-platform-tests.live
+      -d www2.xn--lve-6lad.not-web-platform-tests.live
+      -d www2.xn--lve-6lad.web-platform-tests.live
+      -d www2.xn--n8j6ds53lwwkrqhv28a.not-web-platform-tests.live
+      -d www2.xn--n8j6ds53lwwkrqhv28a.web-platform-tests.live
+      -d xn--lve-6lad.not-web-platform-tests.live
+      -d xn--lve-6lad.web-platform-tests.live
+      -d xn--lve-6lad.www.not-web-platform-tests.live
+      -d xn--lve-6lad.www.web-platform-tests.live
+      -d xn--lve-6lad.www1.not-web-platform-tests.live
+      -d xn--lve-6lad.www1.web-platform-tests.live
+      -d xn--lve-6lad.www2.not-web-platform-tests.live
+      -d xn--lve-6lad.www2.web-platform-tests.live
+      -d xn--lve-6lad.xn--lve-6lad.not-web-platform-tests.live
+      -d xn--lve-6lad.xn--lve-6lad.web-platform-tests.live
+      -d xn--lve-6lad.xn--n8j6ds53lwwkrqhv28a.not-web-platform-tests.live
+      -d xn--lve-6lad.xn--n8j6ds53lwwkrqhv28a.web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.not-web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.www.not-web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.www.web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.www1.not-web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.www1.web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.www2.not-web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.www2.web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.xn--lve-6lad.not-web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.xn--lve-6lad.web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.xn--n8j6ds53lwwkrqhv28a.not-web-platform-tests.live
+      -d xn--n8j6ds53lwwkrqhv28a.xn--n8j6ds53lwwkrqhv28a.web-platform-tests.live
 
   when: cert_file.stat.exists == false
 


### PR DESCRIPTION
The list of subdomains supported by WPT was extended on 2019-01-08 to
include nested subdomains [1]. Specify the complete list when requesting
a TLS certificate from the Let's Encrypt service.

[1] https://github.com/web-platform-tests/wpt/pull/13272