### PR TITLE
Publish previews to top-level directory

### DIFF
--- a/src/mirror-pull-requests.sh
+++ b/src/mirror-pull-requests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Create, update, and delete git worktrees in the `submissions/` subdirectory
-# based on the refs available in the remote repository named "upstream".
+# Create, update, and delete git worktrees based on the refs available in the
+# remote repository named "upstream".
 #
 # Specifically, consider refs in the namespaces `prs-open/*` and
 # `prs-trusted-for-preview/*`. For all refs with identical names in both
@@ -46,8 +46,8 @@ echo active:  $(echo "${active}" | wc --lines)
 
 directories=$(
   git worktree list --porcelain | \
-    grep_tolerate_none "worktree ${PWD}/submissions" | \
-    sed 's/^.*submissions\///g' | \
+    grep_tolerate_none -E "worktree ${PWD}/[0-9]" | \
+    sed "s%^worktree ${PWD}/%%g" | \
     sort
 )
 
@@ -64,17 +64,17 @@ for name in ${to_delete}; do
   # interrupted (e.g. due to reaching disk capacity). Unlock the worktree
   # (tolerating failure in cases where the worktree is not locked), and remove
   # with the `--force` flag to handle cases where the worktree is dirty.
-  git worktree unlock submissions/${name} 2> /dev/null || \
-    echo Worktree \'submissions/${name}\' is not locked
-  git worktree remove --force submissions/${name}
+  git worktree unlock ${name} 2> /dev/null || \
+    echo Worktree \'${name}\' is not locked
+  git worktree remove --force ${name}
 done
 
 for name in ${to_update}; do
-  (cd submissions/${name} && git checkout refs/prs-open/${name})
+  (cd ${name} && git checkout refs/prs-open/${name})
 done
 
 for name in ${to_create}; do
-  git worktree add submissions/${name} refs/prs-open/${name}
+  git worktree add ${name} refs/prs-open/${name}
 done
 
 git worktree prune

--- a/test/test_mirror-pull-requests.py
+++ b/test/test_mirror-pull-requests.py
@@ -61,87 +61,83 @@ def repos():
 
 def test_okay(repos):
     remote_refs = [
-        'refs/prs-open/gh-1',
-        'refs/prs-open/gh-2',
-        'refs/prs-open/gh-3',
-        'refs/prs-open/gh-4',
-        'refs/prs-trusted-for-preview/gh-2',
-        'refs/prs-trusted-for-preview/gh-3',
-        'refs/prs-trusted-for-preview/gh-4',
-        'refs/prs-trusted-for-preview/gh-5'
+        'refs/prs-open/1',
+        'refs/prs-open/2',
+        'refs/prs-open/3',
+        'refs/prs-open/4',
+        'refs/prs-trusted-for-preview/2',
+        'refs/prs-trusted-for-preview/3',
+        'refs/prs-trusted-for-preview/4',
+        'refs/prs-trusted-for-preview/5'
     ]
     for ref in remote_refs:
         repos.remote.cmd(['git', 'update-ref', ref, 'HEAD'])
     local_refs = [
-        'refs/prs-open/gh-2',
-        'refs/prs-open/gh-6',
-        'refs/prs-trusted-for-preview/gh-2',
-        'refs/prs-trusted-for-preview/gh-6'
+        'refs/prs-open/2',
+        'refs/prs-open/6',
+        'refs/prs-trusted-for-preview/2',
+        'refs/prs-trusted-for-preview/6'
     ]
     for ref in local_refs:
         repos.local.cmd(['git', 'update-ref', ref, 'HEAD'])
 
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-2', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-6', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '2', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '6', 'HEAD'])
 
     subprocess.check_call(subject, cwd=repos.local.cwd)
 
-    expected = set((
-        'submissions/gh-2', 'submissions/gh-3', 'submissions/gh-4'
-    ))
+    expected = set(('2', '3', '4'))
     assert expected == set(repos.local.worktrees())
 
 
 def test_create(repos):
-    repos.remote.update_ref('refs/prs-open/gh-100', 'HEAD')
-    repos.remote.update_ref('refs/prs-open/gh-101', 'HEAD')
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-100', 'HEAD')
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-101', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/100', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/101', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/100', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/101', 'HEAD')
     # Opened but not trusted:
-    repos.remote.update_ref('refs/prs-open/gh-200', 'HEAD')
-    repos.remote.update_ref('refs/prs-open/gh-201', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/200', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/201', 'HEAD')
     # Trusted but not open:
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-300', 'HEAD')
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-301', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/300', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/301', 'HEAD')
 
     subprocess.check_call(subject, cwd=repos.local.cwd)
 
-    expected = set((
-        'submissions/gh-100', 'submissions/gh-101'
-    ))
+    expected = set(('100', '101'))
     assert expected == set(repos.local.worktrees())
 
 
 def test_update(repos):
-    repos.local.update_ref('refs/prs-open/gh-100', 'HEAD')
-    repos.local.update_ref('refs/prs-open/gh-101', 'HEAD')
-    repos.local.update_ref('refs/prs-open/gh-200', 'HEAD')
-    repos.local.update_ref('refs/prs-open/gh-201', 'HEAD')
-    repos.local.update_ref('refs/prs-trusted-for-preview/gh-100', 'HEAD')
-    repos.local.update_ref('refs/prs-trusted-for-preview/gh-101', 'HEAD')
-    repos.local.update_ref('refs/prs-trusted-for-preview/gh-200', 'HEAD')
-    repos.local.update_ref('refs/prs-trusted-for-preview/gh-201', 'HEAD')
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-100', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-101', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-200', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-201', 'HEAD'])
+    repos.local.update_ref('refs/prs-open/100', 'HEAD')
+    repos.local.update_ref('refs/prs-open/101', 'HEAD')
+    repos.local.update_ref('refs/prs-open/200', 'HEAD')
+    repos.local.update_ref('refs/prs-open/201', 'HEAD')
+    repos.local.update_ref('refs/prs-trusted-for-preview/100', 'HEAD')
+    repos.local.update_ref('refs/prs-trusted-for-preview/101', 'HEAD')
+    repos.local.update_ref('refs/prs-trusted-for-preview/200', 'HEAD')
+    repos.local.update_ref('refs/prs-trusted-for-preview/201', 'HEAD')
+    repos.local.cmd(['git', 'worktree', 'add', '100', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '101', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '200', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '201', 'HEAD'])
 
-    repos.remote.update_ref('refs/prs-open/gh-100', 'HEAD')
-    repos.remote.update_ref('refs/prs-open/gh-101', 'HEAD')
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-100', 'HEAD')
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-101', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/100', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/101', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/100', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/101', 'HEAD')
 
     repos.remote.cmd(['git', 'commit', '--allow-empty', '--message', 'second'])
-    repos.remote.update_ref('refs/prs-open/gh-200', 'HEAD')
-    repos.remote.update_ref('refs/prs-open/gh-201', 'HEAD')
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-200', 'HEAD')
-    repos.remote.update_ref('refs/prs-trusted-for-preview/gh-201', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/200', 'HEAD')
+    repos.remote.update_ref('refs/prs-open/201', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/200', 'HEAD')
+    repos.remote.update_ref('refs/prs-trusted-for-preview/201', 'HEAD')
 
     old_revision = repos.remote.cmd(['git', 'rev-parse', 'HEAD~'])
     new_revision = repos.remote.cmd(['git', 'rev-parse', 'HEAD'])
 
     def get_worktree_revision(name):
-        directory = os.path.join(repos.local.cwd, 'submissions', name)
+        directory = os.path.join(repos.local.cwd, name)
 
         return subprocess.check_output(
             ['git', 'rev-parse', 'HEAD'], cwd=directory
@@ -149,117 +145,111 @@ def test_update(repos):
 
     subprocess.check_call(subject, cwd=repos.local.cwd)
 
-    assert get_worktree_revision('gh-100') == old_revision
-    assert get_worktree_revision('gh-101') == old_revision
-    assert get_worktree_revision('gh-200') == new_revision
-    assert get_worktree_revision('gh-201') == new_revision
+    assert get_worktree_revision('100') == old_revision
+    assert get_worktree_revision('101') == old_revision
+    assert get_worktree_revision('200') == new_revision
+    assert get_worktree_revision('201') == new_revision
 
 
 def test_prune_removed_labels(repos):
     refs = [
-        'refs/prs-open/gh-11',
-        'refs/prs-open/gh-23',
-        'refs/prs-open/gh-33',
-        'refs/prs-open/gh-45',
-        'refs/prs-open/gh-55',
-        'refs/prs-trusted-for-preview/gh-11',
-        'refs/prs-trusted-for-preview/gh-23',
-        'refs/prs-trusted-for-preview/gh-33',
-        'refs/prs-trusted-for-preview/gh-45',
-        'refs/prs-trusted-for-preview/gh-55'
+        'refs/prs-open/11',
+        'refs/prs-open/23',
+        'refs/prs-open/33',
+        'refs/prs-open/45',
+        'refs/prs-open/55',
+        'refs/prs-trusted-for-preview/11',
+        'refs/prs-trusted-for-preview/23',
+        'refs/prs-trusted-for-preview/33',
+        'refs/prs-trusted-for-preview/45',
+        'refs/prs-trusted-for-preview/55'
     ]
     for ref in refs:
         repos.remote.update_ref(ref, 'HEAD')
         repos.local.update_ref(ref, 'HEAD')
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-11', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-23', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-33', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-45', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-55', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '11', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '23', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '33', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '45', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '55', 'HEAD'])
 
     # Simulate removing labels
-    repos.remote.delete_ref('refs/prs-trusted-for-preview/gh-23')
-    repos.remote.delete_ref('refs/prs-trusted-for-preview/gh-45')
+    repos.remote.delete_ref('refs/prs-trusted-for-preview/23')
+    repos.remote.delete_ref('refs/prs-trusted-for-preview/45')
 
     subprocess.check_call(subject, cwd=repos.local.cwd)
 
-    expected = set((
-        'submissions/gh-11', 'submissions/gh-33', 'submissions/gh-55'
-    ))
+    expected = set(('11', '33', '55'))
     assert expected == set(repos.local.worktrees())
 
 
 def test_prune_closed_branches(repos):
     refs = [
-        'refs/prs-open/gh-11',
-        'refs/prs-trusted-for-preview/gh-11',
-        'refs/prs-open/gh-23',
-        'refs/prs-trusted-for-preview/gh-23',
-        'refs/prs-open/gh-33',
-        'refs/prs-trusted-for-preview/gh-33',
-        'refs/prs-open/gh-45',
-        'refs/prs-trusted-for-preview/gh-45',
-        'refs/prs-open/gh-55',
-        'refs/prs-trusted-for-preview/gh-55'
+        'refs/prs-open/11',
+        'refs/prs-trusted-for-preview/11',
+        'refs/prs-open/23',
+        'refs/prs-trusted-for-preview/23',
+        'refs/prs-open/33',
+        'refs/prs-trusted-for-preview/33',
+        'refs/prs-open/45',
+        'refs/prs-trusted-for-preview/45',
+        'refs/prs-open/55',
+        'refs/prs-trusted-for-preview/55'
     ]
     for ref in refs:
         repos.remote.update_ref(ref, 'HEAD')
         repos.local.update_ref(ref, 'HEAD')
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-11', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-23', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-33', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-45', 'HEAD'])
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-55', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '11', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '23', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '33', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '45', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '55', 'HEAD'])
 
     # Simulate closing pull requests
-    repos.remote.delete_ref('refs/prs-open/gh-23')
-    repos.remote.delete_ref('refs/prs-open/gh-45')
+    repos.remote.delete_ref('refs/prs-open/23')
+    repos.remote.delete_ref('refs/prs-open/45')
 
     subprocess.check_call(subject, cwd=repos.local.cwd)
 
-    expected = set((
-        'submissions/gh-11', 'submissions/gh-33', 'submissions/gh-55'
-    ))
+    expected = set(('11', '33', '55'))
     assert expected == set(repos.local.worktrees())
 
 
 def test_prune_closed_branches_corrupt_worktree(repos):
     refs = [
-        'refs/prs-open/gh-11',
-        'refs/prs-trusted-for-preview/gh-11',
-        'refs/prs-open/gh-23',
-        'refs/prs-trusted-for-preview/gh-23',
+        'refs/prs-open/11',
+        'refs/prs-trusted-for-preview/11',
+        'refs/prs-open/23',
+        'refs/prs-trusted-for-preview/23',
     ]
     for ref in refs:
         repos.remote.update_ref(ref, 'HEAD')
         repos.local.update_ref(ref, 'HEAD')
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-11', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '11', 'HEAD'])
 
     # Simulate a worktree whose initial creation was interrupted
     repos.local.cmd([
         'git', 'worktree', 'lock', '--reason', 'initializing',
-        'submissions/gh-11'
+        '11'
     ])
-    extra_file_path = os.path.join(
-        repos.local.cwd, 'submissions', 'gh-11', 'extra-file'
-    )
+    extra_file_path = os.path.join(repos.local.cwd, '11', 'extra-file')
     with open(extra_file_path, 'w') as handle:
         handle.write('this file is not under version control')
 
     # Simulate closing pull requests
-    repos.remote.delete_ref('refs/prs-open/gh-11')
+    repos.remote.delete_ref('refs/prs-open/11')
 
     subprocess.check_call(subject, cwd=repos.local.cwd)
 
-    expected = set(('submissions/gh-23',))
+    expected = set(('23',))
     assert expected == set(repos.local.worktrees())
 
 
 def test_nothing_trusted(repos):
-    ref = 'refs/prs-open/gh-11'
+    ref = 'refs/prs-open/11'
     repos.remote.update_ref(ref, 'HEAD')
     repos.local.update_ref(ref, 'HEAD')
-    repos.local.cmd(['git', 'worktree', 'add', 'submissions/gh-11', 'HEAD'])
+    repos.local.cmd(['git', 'worktree', 'add', '11', 'HEAD'])
 
     subprocess.check_call(subject, cwd=repos.local.cwd)
 


### PR DESCRIPTION
Move previews from the `submissions/` directory to the server root and
operate on git refs whose names are integers (in other words, remove the
"gh-" prefix).

---

@foolip I'm a bit wary to use unadorned integers as identifiers. That could be
confusing in some contexts. The system would seem more coherent to me if it
qualified these in some way, such as GitHub's own "gh-" prefix. In the interest
of consistency, that'd show up in the URLs as well, but I wonder if you feel
http://wptpr.live/gh-1234 is overly long or redundant.