### PR TITLE
bugfix: Fix cert renewal

### DIFF
--- a/cert-renewer-requirements.txt
+++ b/cert-renewer-requirements.txt
@@ -1,0 +1,3 @@
+acme==4.1.1
+certbot==4.1.1
+certbot-dns-google==4.1.1

--- a/cert-renewer.Dockerfile
+++ b/cert-renewer.Dockerfile
@@ -8,26 +8,25 @@ ENV WPT_HOST=wpt.live \
   WPT_ALT_HOST=not-wpt.live \
   WPT_BUCKET=wpt-live
 
-# Pin the versions of python and google cloud cli for repeatable builds
-# For ubuntu package versions, go to https://packages.ubuntu.com/
-#   Search for the package with the "jammy" distribution (aka 22.04) selected.
+# Search for the packages with the "jammy" distribution (aka 22.04) selected on https://packages.ubuntu.com/.
 RUN apt-get -qqy update && \
   apt-get -qqy install \
     apt-transport-https \
     ca-certificates \
     curl \
     gnupg \
-    python3=3.10.6-1~22.04.1 \
-    python3-dev=3.10.6-1~22.04.1 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.5
+    python3.10 \
+    python3.10-dev \
+    python3-pip
 # For Google Cloud, look under https://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages
 # https://cloud.google.com/storage/docs/gsutil_install
 # Copy the "Docker Tip" instructions from gsutil_install link and then pin the version
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli=451.0.1-0 -y
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli=526.0.1-0 -y
 
 # Instructions for certbot installation
 # https://certbot.eff.org/instructions?ws=other&os=pip
-RUN pip install acme==1.29.0 certbot==1.29.0 certbot-dns-google==1.29.0
+COPY cert-renewer-requirements.txt requirements.txt
+RUN pip install -r requirements.txt
 
 COPY src/cert-store.sh /usr/local/bin/
 

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.6.2",
-  "serial": 289,
+  "serial": 298,
   "lineage": "93d46d9c-57ba-2cec-a13b-46298c0751ec",
   "outputs": {
     "wpt-live-address": {
@@ -92,9 +92,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "sha256:029a3b2e90d2b74a7453f237af5c4fd346ac5673ca9f6e8a7bb7f4ccc9867d34",
+            "id": "sha256:2a448949978e21356a3003926a2d7646046193ada20038f2252aaeb286a56472",
             "name": "gcr.io/wpt-live-app/wpt-live-cert-renewer:latest",
-            "repo_digest": "gcr.io/wpt-live-app/wpt-live-cert-renewer@sha256:b067affafee033a8206a18a7230f314f4769b817eeba7493cafedc2282c3723f"
+            "repo_digest": "gcr.io/wpt-live-app/wpt-live-cert-renewer@sha256:806d59f4764ea12fa6bc7aeea80efe90846ab4709b111e1d5bd3d9ab671e8f6f"
           },
           "sensitive_attributes": []
         }
@@ -199,24 +199,24 @@
             "create_time": "2023-10-24T14:36:06.871869Z",
             "creator": "jamescscott@google.com",
             "delete_time": "",
-            "etag": "\"CNC_6MAGENijiDc/cHJvamVjdHMvd3B0LWxpdmUtYXBwL2xvY2F0aW9ucy91cy1jZW50cmFsMS9qb2JzL3dwdC10b3QtYXBwLWNlcnQtcmVuZXdlcnM\"",
-            "execution_count": 562,
+            "etag": "\"CMqgscIGEODrndAC/cHJvamVjdHMvd3B0LWxpdmUtYXBwL2xvY2F0aW9ucy91cy1jZW50cmFsMS9qb2JzL3dwdC10b3QtYXBwLWNlcnQtcmVuZXdlcnM\"",
+            "execution_count": 601,
             "expire_time": "",
-            "generation": "2",
+            "generation": "3",
             "id": "projects/wpt-live-app/locations/us-central1/jobs/wpt-tot-app-cert-renewers",
             "labels": {},
             "last_modifier": "jamescscott@google.com",
             "latest_created_execution": [
               {
-                "completion_time": "2025-05-06T00:02:57.524979Z",
-                "create_time": "2025-05-06T00:00:01.496371Z",
-                "name": "wpt-tot-app-cert-renewers-9scn7"
+                "completion_time": "2025-06-13T16:27:27.694533Z",
+                "create_time": "2025-06-13T16:24:01.144163Z",
+                "name": "wpt-tot-app-cert-renewers-qtlts"
               }
             ],
             "launch_stage": "GA",
             "location": "us-central1",
             "name": "wpt-tot-app-cert-renewers",
-            "observed_generation": "2",
+            "observed_generation": "3",
             "project": "wpt-live-app",
             "reconciling": false,
             "template": [
@@ -248,7 +248,7 @@
                             "value_source": []
                           }
                         ],
-                        "image": "gcr.io/wpt-live-app/wpt-live-cert-renewer@sha256:b067affafee033a8206a18a7230f314f4769b817eeba7493cafedc2282c3723f",
+                        "image": "gcr.io/wpt-live-app/wpt-live-cert-renewer@sha256:806d59f4764ea12fa6bc7aeea80efe90846ab4709b111e1d5bd3d9ab671e8f6f",
                         "liveness_probe": [],
                         "name": "",
                         "ports": [],
@@ -290,7 +290,7 @@
             ],
             "timeouts": null,
             "uid": "8003276c-d47c-42b6-b171-b2bf451d1043",
-            "update_time": "2025-05-06T14:42:24.115479Z"
+            "update_time": "2025-06-13T16:22:34.705132Z"
           },
           "sensitive_attributes": [],
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
@@ -933,7 +933,7 @@
             ],
             "base_instance_name": "wpt-tot-app-wpt-servers",
             "description": "compute VM Instance Group",
-            "fingerprint": "qvYgsyNU75g=",
+            "fingerprint": "HYyOMy7guno=",
             "id": "projects/wpt-live-app/zones/us-central1-b/instanceGroupManagers/wpt-tot-app-wpt-servers",
             "instance_group": "https://www.googleapis.com/compute/v1/projects/wpt-live-app/zones/us-central1-b/instanceGroups/wpt-tot-app-wpt-servers",
             "instance_lifecycle_policy": [
@@ -979,7 +979,7 @@
             "stateful_disk": [],
             "status": [
               {
-                "is_stable": true,
+                "is_stable": false,
                 "stateful": [
                   {
                     "has_stateful_config": false,
@@ -992,7 +992,7 @@
                 ],
                 "version_target": [
                   {
-                    "is_reached": true
+                    "is_reached": false
                   }
                 ]
               }
@@ -1016,7 +1016,7 @@
             ],
             "version": [
               {
-                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live-app/global/instanceTemplates/default-20250506144812248100000001",
+                "instance_template": "https://www.googleapis.com/compute/v1/projects/wpt-live-app/global/instanceTemplates/default-20250613193202312900000001",
                 "name": "wpt-tot-app-wpt-servers-default",
                 "target_size": []
               }
@@ -1052,7 +1052,7 @@
           "attributes": {
             "advanced_machine_features": [],
             "can_ip_forward": false,
-            "confidential_instance_config": [],
+            "confidential_instance_config": null,
             "description": "",
             "disk": [
               {
@@ -1064,12 +1064,12 @@
                 "disk_size_gb": 0,
                 "disk_type": "pd-ssd",
                 "interface": "SCSI",
-                "labels": {},
+                "labels": null,
                 "mode": "READ_WRITE",
                 "provisioned_iops": 0,
-                "resource_policies": [],
+                "resource_policies": null,
                 "source": "",
-                "source_image": "projects/cos-cloud/global/images/cos-stable-117-18613-164-124",
+                "source_image": "projects/cos-cloud/global/images/cos-stable-121-18867-90-59",
                 "source_image_encryption_key": [],
                 "source_snapshot": "",
                 "source_snapshot_encryption_key": [],
@@ -1077,22 +1077,22 @@
               }
             ],
             "guest_accelerator": [],
-            "id": "projects/wpt-live-app/global/instanceTemplates/default-20250506144812248100000001",
+            "id": "projects/wpt-live-app/global/instanceTemplates/default-20250613193202312900000001",
             "instance_description": "",
             "labels": {
-              "container-vm": "cos-stable-117-18613-164-124"
+              "container-vm": "cos-stable-121-18867-90-59"
             },
             "machine_type": "e2-medium",
             "metadata": {
-              "gce-container-declaration": "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"WPT_HOST\"\n      \"value\": \"wpt.live\"\n    - \"name\": \"WPT_ALT_HOST\"\n      \"value\": \"not-wpt.live\"\n    - \"name\": \"WPT_BUCKET\"\n      \"value\": \"wpt-tot-app-certificates\"\n    \"image\": \"gcr.io/wpt-live-app/wpt-live-wpt-server-tot@sha256:9b82ef82950f1a23a1e553f4657c3790b2e432c072c8de227cd84a063075ddce\"\n  \"restartPolicy\": \"Always\"\n  \"volumes\": []\n",
+              "gce-container-declaration": "\"spec\":\n  \"containers\":\n  - \"env\":\n    - \"name\": \"WPT_HOST\"\n      \"value\": \"wpt.live\"\n    - \"name\": \"WPT_ALT_HOST\"\n      \"value\": \"not-wpt.live\"\n    - \"name\": \"WPT_BUCKET\"\n      \"value\": \"wpt-tot-app-certificates\"\n    \"image\": \"gcr.io/wpt-live-app/wpt-live-wpt-server-tot@sha256:e9aa7d5bc5930bb8ba4ed749fc5d955e5bb9b014abf91dedbde39c6925281ff0\"\n  \"restartPolicy\": \"Always\"\n  \"volumes\": []\n",
               "google-logging-enabled": "true",
               "startup-script": "",
               "tf_depends_id": ""
             },
-            "metadata_fingerprint": "c4qsyfsW3Ao=",
+            "metadata_fingerprint": "6pbpq1TuRxs=",
             "metadata_startup_script": null,
             "min_cpu_platform": "",
-            "name": "default-20250506144812248100000001",
+            "name": "default-20250613193202312900000001",
             "name_prefix": "default-",
             "network_interface": [
               {
@@ -1135,8 +1135,8 @@
                 "provisioning_model": "STANDARD"
               }
             ],
-            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live-app/global/instanceTemplates/default-20250506144812248100000001",
-            "self_link_unique": "https://www.googleapis.com/compute/v1/projects/wpt-live-app/global/instanceTemplates/default-20250506144812248100000001?uniqueId=8807221264062586819",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/wpt-live-app/global/instanceTemplates/default-20250613193202312900000001",
+            "self_link_unique": "https://www.googleapis.com/compute/v1/projects/wpt-live-app/global/instanceTemplates/default-20250613193202312900000001?uniqueId=9063920210827919965",
             "service_account": [
               {
                 "email": "default",
@@ -1147,7 +1147,7 @@
               }
             ],
             "shielded_instance_config": [],
-            "tags": [],
+            "tags": null,
             "tags_fingerprint": "",
             "timeouts": null
           },
@@ -1181,8 +1181,8 @@
             ],
             "id": "projects/wpt-live-app/regions/us-central1/targetPools/wpt-tot-app-load-balancing",
             "instances": [
-              "us-central1-b/wpt-tot-app-wpt-servers-33nv",
-              "us-central1-b/wpt-tot-app-wpt-servers-7gxp"
+              "us-central1-b/wpt-tot-app-wpt-servers-2xj5",
+              "us-central1-b/wpt-tot-app-wpt-servers-655d"
             ],
             "name": "wpt-tot-app-load-balancing",
             "project": "wpt-live-app",
@@ -1424,30 +1424,30 @@
         {
           "schema_version": 0,
           "attributes": {
-            "archive_size_bytes": 1907636160,
-            "creation_timestamp": "2025-04-29T13:49:18.409-07:00",
-            "description": "Google, Container-Optimized OS, 117-18613.164.124 stable, Kernel: COS-6.6.72 Kubernetes: 1.30.3 Docker: 24.0.9 Family: cos-stable",
+            "archive_size_bytes": 1931812224,
+            "creation_timestamp": "2025-06-10T16:58:11.795-07:00",
+            "description": "Google, Container-Optimized OS, 121-18867.90.59 stable, Kernel: COS-6.6.87 Kubernetes: 1.30.3 Docker: 27.5.1 Family: cos-stable",
             "disk_size_gb": 10,
             "family": "cos-stable",
             "filter": null,
-            "id": "projects/cos-cloud/global/images/cos-stable-117-18613-164-124",
+            "id": "projects/cos-cloud/global/images/cos-stable-121-18867-90-59",
             "image_encryption_key_sha256": "",
-            "image_id": "5949804630412920226",
-            "label_fingerprint": "6a05UBQMhWk=",
+            "image_id": "2494191935395559548",
+            "label_fingerprint": "c57SMzoVwZI=",
             "labels": {
-              "build_number": "18613-164-124",
-              "milestone": "117",
+              "build_number": "18867-90-59",
+              "milestone": "121",
               "public-image": "true"
             },
             "licenses": [
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos-pcid",
               "https://www.googleapis.com/compute/v1/projects/cos-cloud-shielded/global/licenses/shielded-cos",
-              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos",
-              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos-pcid"
+              "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/licenses/cos"
             ],
             "most_recent": false,
-            "name": "cos-stable-117-18613-164-124",
+            "name": "cos-stable-121-18867-90-59",
             "project": "cos-cloud",
-            "self_link": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-117-18613-164-124",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-stable-121-18867-90-59",
             "source_disk": "",
             "source_disk_encryption_key_sha256": "",
             "source_disk_id": "",
@@ -1468,9 +1468,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "sha256:91e4a0a18efb18331fa8dc75c9533efc2165685bd537446aa59a55f4c10e1587",
+            "id": "sha256:9759f68b8345171ea4709ed0de979530b99c3c992021cbee9a5cdc9d5fc5858c",
             "name": "gcr.io/wpt-live-app/wpt-live-wpt-server-tot:latest",
-            "repo_digest": "gcr.io/wpt-live-app/wpt-live-wpt-server-tot@sha256:9b82ef82950f1a23a1e553f4657c3790b2e432c072c8de227cd84a063075ddce"
+            "repo_digest": "gcr.io/wpt-live-app/wpt-live-wpt-server-tot@sha256:e9aa7d5bc5930bb8ba4ed749fc5d955e5bb9b014abf91dedbde39c6925281ff0"
           },
           "sensitive_attributes": []
         }

--- a/wpt-server-tot.Dockerfile
+++ b/wpt-server-tot.Dockerfile
@@ -4,9 +4,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
 
-# Pin the versions of python and google cloud cli for repeatable builds
-# For ubuntu package versions, go to https://packages.ubuntu.com/
-#   Search for the package with the "jammy" distribution (aka 22.04) selected.
+# Search for the packages with the "jammy" distribution (aka 22.04) selected on https://packages.ubuntu.com/.
 RUN \
   apt-get -qqy update && \
   apt-get -qqy install \
@@ -17,16 +15,16 @@ RUN \
     git \
     gnupg \
     locales \
-    python3=3.10.6-1~22.04.1 \
-    python3-dev=3.10.6-1~22.04.1 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.5 \
-    python3-venv=3.10.6-1~22.04.1 \
+    python3.10 \
+    python3.10-dev \
+    python3.10-venv \
+    python3-pip \
     supervisor \
     tzdata
 # For Google Cloud, look under https://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages
 # https://cloud.google.com/storage/docs/gsutil_install
 # Copy the "Docker Tip" instructions from gsutil_install link and then pin the version
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli=451.0.1-0 -y
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli=526.0.1-0 -y
 
 
 


### PR DESCRIPTION
We received an alert yesterday that the certificate for wpt.live is going to expire.

Upon looking at the logs, it showed this error:

```
AttributeError: module 'josepy' has no attribute 'ComparableX509'. Did you mean: 'ComparableKey'?
```

Which looks like this issue: https://github.com/certbot/certbot/issues/10185

Thid changes bumps the python libraries and moves them into a requirements.txt for the cert renewer python process image

Also simplified some of the package pinning to only the minor version where able (all but the pip dpkg)

This PR contains the deployed changes that resolved the alert.